### PR TITLE
Updated brew tap instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Quit your editor/program. Unzip and open the folder.
 * **Instructions for Windows**: Download the fonts from the [Releases](https://github.com/be5invis/Iosevka/releases), select the font files and right click, then hit "Install".
   * On Windows 10 1809 or newer the default font installation is per-user, and it may cause compatibility issues for some applications, mostly written in Java. To cope with this, right click and select "Install for all users" instead. [Ref.](https://youtrack.jetbrains.com/issue/JRE-1166?p=IDEA-200145)
 * **[Instructions for macOS](http://support.apple.com/kb/HT2509)**
-  * Standard distribution in Homebrew: `brew tap caskroom/fonts && brew cask install font-iosevka` (May be outdated).
+  * Standard distribution in Homebrew: `brew tap homebrew/cask-fonts && brew cask install font-iosevka` (May be outdated).
   * Customizable install using Homebrew: see [robertgzr/homebrew-tap](https://github.com/robertgzr/homebrew-tap).
 * **Linux** : Copy the TTF files to your fonts directory → Run `sudo fc-cache`. 
   - Arch Linux users can install the font from the AUR [here](https://aur.archlinux.org/packages/ttf-iosevka) using an AUR wrapper or by doing it manually. [All variants](https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ttf-iosevka&SB=n&SO=a&PP=50&do_Search=Go).


### PR DESCRIPTION
`brew tap caskroom/fonts` -> `brew tap homebrew/cask-fonts`

Using the former results in `Error: caskroom/cask-fonts was moved. Tap homebrew/cask-fonts instead.`